### PR TITLE
Update prometheus.yaml

### DIFF
--- a/prometheus.yaml
+++ b/prometheus.yaml
@@ -248,7 +248,7 @@ objects:
 
         - name: prometheus
           args:
-          - --storage.tsdb.retention=6h
+          - --storage.tsdb.retention.time=6h
           - --storage.tsdb.min-block-duration=2h
           - --storage.tsdb.max-block-duration=2h
           - --config.file=/etc/prometheus/prometheus.yml


### PR DESCRIPTION
retention flag has changed from `--storage.tsdb.retention=6h` to `--storage.tsdb.retention.time=6h` in the newer versions of prometheus